### PR TITLE
Fix #33. Set custom getter for the Eloquent key name.

### DIFF
--- a/app/Agreement.php
+++ b/app/Agreement.php
@@ -47,4 +47,14 @@ class Agreement extends Model
     {
         return 'uuid';
     }
+
+    /**
+     * Getter to integrate uuid value into Eloquent functionality
+     *
+     * @return void
+     */
+    public function getKeyName()
+    {
+        return 'uuid';
+    }
 }

--- a/tests/Unit/AgreementTest.php
+++ b/tests/Unit/AgreementTest.php
@@ -13,7 +13,6 @@ class AgreementTest extends TestCase
     public function it_tracks_the_order_identifier()
     {
         $agreement = factory(\App\Agreement::class)->create();
-
         $this->assertNotNull($agreement->order);
     }
 
@@ -21,8 +20,14 @@ class AgreementTest extends TestCase
     public function it_tracks_the_release_identifier()
     {
         $agreement = factory(\App\Agreement::class)->create();
-
         $this->assertNotNull($agreement->release);
+    }
+
+    /** @test */
+    public function it_allows_release_identifier_to_be_null()
+    {
+        $agreement = factory(\App\Agreement::class)->create(['release' => null]);
+        $this->assertNull($agreement->release);
     }
 
     /** @test */
@@ -76,5 +81,17 @@ class AgreementTest extends TestCase
         $this->assertEquals($releaseId, $newAgreement->release);
         $this->assertEquals($effectiveDate, $newAgreement->effective_date);
         $this->assertEquals($totalValue, $newAgreement->total_value);
+    }
+
+    /** @test */
+    public function it_integrates_with_eloquent_find()
+    {
+        $agreement = factory(\App\Agreement::class)->create();
+        $agreementFound = \App\Agreement::find($agreement->uuid);
+
+        $this->assertEquals($agreement->uuid, $agreementFound->uuid);
+
+        $agreementSearched = \App\Agreement::where('uuid', $agreement->uuid)->get();
+        $this->assertCount(1, $agreementSearched);
     }
 }


### PR DESCRIPTION
# Pull Request

Fixes #33 Eloquent integration.

## Approach

- Added support for basic eloquent commands by implementing a custom getter for the Eloquent key name.

## Lessons Learned

Looking through the \Illuminate\Database\Eloquent\Model abstract class I found that the keyName attribute is used throughout the class to implement Eloquent methods. A simple search then revealed that the override just needed to be implemented.